### PR TITLE
Add configuration option "use_application_secret"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Doorkeeper::JWT.configure do
     }
   end
 
+  # Use the application secret specified in the Access Grant token
+  # Defaults to false
+  # If you specify `use_application_secret true`, both secret_key and secret_key_path will be ignored
+  use_application_secret false
+
   # Set the encryption secret. This would be shared with any other applications
   # that should be able to read the payload of the token.
   # Defaults to "secret"

--- a/lib/doorkeeper-jwt.rb
+++ b/lib/doorkeeper-jwt.rb
@@ -19,10 +19,11 @@ module Doorkeeper
     end
 
     def self.secret_key(opts)
+      opts = { application: {} }.merge(opts)
+
       if Doorkeeper::JWT.configuration.use_application_secret
-        if opts[:application] && opts[:application][:secret]
-          return opts[:application][:secret]
-        end
+        return opts[:application][:secret] if opts[:application][:secret]
+
         fail "`use_application_secret` config set, but no app had no secret."
       end
 

--- a/lib/doorkeeper-jwt.rb
+++ b/lib/doorkeeper-jwt.rb
@@ -16,11 +16,13 @@ module Doorkeeper
 
     def self.token_payload(opts = {})
       Doorkeeper::JWT.configuration.token_payload.call opts
-
     end
 
     def self.secret_key(opts)
-      return opts[:application][:secret] if Doorkeeper::JWT.configuration.use_application_secret
+      if Doorkeeper::JWT.configuration.use_application_secret
+        return opts[:application][:secret]
+      end
+
       return secret_key_file if !secret_key_file.nil?
       return rsa_key if rsa_encryption?
       Doorkeeper::JWT.configuration.secret_key

--- a/lib/doorkeeper-jwt.rb
+++ b/lib/doorkeeper-jwt.rb
@@ -7,7 +7,7 @@ module Doorkeeper
     def self.generate(opts = {})
       ::JWT.encode(
         token_payload(opts),
-        secret_key,
+        secret_key(opts),
         encryption_method
       )
     end
@@ -16,9 +16,11 @@ module Doorkeeper
 
     def self.token_payload(opts = {})
       Doorkeeper::JWT.configuration.token_payload.call opts
+
     end
 
-    def self.secret_key
+    def self.secret_key(opts)
+      return opts[:application][:secret] if Doorkeeper::JWT.configuration.use_application_secret
       return secret_key_file if !secret_key_file.nil?
       return rsa_key if rsa_encryption?
       Doorkeeper::JWT.configuration.secret_key

--- a/lib/doorkeeper-jwt.rb
+++ b/lib/doorkeeper-jwt.rb
@@ -20,7 +20,10 @@ module Doorkeeper
 
     def self.secret_key(opts)
       if Doorkeeper::JWT.configuration.use_application_secret
-        return opts[:application][:secret]
+        if opts[:application] && opts[:application][:secret]
+          return opts[:application][:secret]
+        end
+        fail "`use_application_secret` config set, but no app had no secret."
       end
 
       return secret_key_file if !secret_key_file.nil?

--- a/lib/doorkeeper-jwt/config.rb
+++ b/lib/doorkeeper-jwt/config.rb
@@ -26,7 +26,10 @@ module Doorkeeper
         end
 
         def use_application_secret(use_application_secret)
-          @config.instance_variable_set('@use_application_secret', use_application_secret)
+          @config.instance_variable_set(
+            "@use_application_secret",
+            use_application_secret
+          )
         end
 
         def secret_key(secret_key)
@@ -128,7 +131,6 @@ module Doorkeeper
       def encryption_method
         @encryption_method ||= nil
       end
-
     end
   end
 end

--- a/lib/doorkeeper-jwt/config.rb
+++ b/lib/doorkeeper-jwt/config.rb
@@ -25,6 +25,10 @@ module Doorkeeper
           @config
         end
 
+        def use_application_secret(use_application_secret)
+          @config.instance_variable_set('@use_application_secret', use_application_secret)
+        end
+
         def secret_key(secret_key)
           @config.instance_variable_set('@secret_key', secret_key)
         end
@@ -104,9 +108,14 @@ module Doorkeeper
 
       option :token_payload,
         default: proc{ { token: SecureRandom.method(:hex) } }
+      option :use_application_secret, default: false
       option :secret_key, default: nil
       option :secret_key_path, default: nil
       option :encryption_method, default: nil
+
+      def use_application_secret
+        @use_application_secret ||= false
+      end
 
       def secret_key
         @secret_key ||= nil
@@ -119,6 +128,7 @@ module Doorkeeper
       def encryption_method
         @encryption_method ||= nil
       end
+
     end
   end
 end

--- a/spec/doorkeeper-jwt/config_spec.rb
+++ b/spec/doorkeeper-jwt/config_spec.rb
@@ -35,8 +35,8 @@ describe Doorkeeper::JWT, 'configuration' do
     end
   end
 
-  describe 'use_application_secret' do
-    it 'defaults to false' do
+  describe "use_application_secret" do
+    it "defaults to false" do
       Doorkeeper::JWT.configure do
       end
       expect(subject.use_application_secret).to be false

--- a/spec/doorkeeper-jwt/config_spec.rb
+++ b/spec/doorkeeper-jwt/config_spec.rb
@@ -42,7 +42,7 @@ describe Doorkeeper::JWT, 'configuration' do
       expect(subject.use_application_secret).to be false
     end
 
-    it 'changes the value of secret_key to the applicatin\'s secret' do
+    it "changes the value of secret_key to the application's secret" do
       Doorkeeper::JWT.configure do
         use_application_secret true
       end

--- a/spec/doorkeeper-jwt/config_spec.rb
+++ b/spec/doorkeeper-jwt/config_spec.rb
@@ -35,6 +35,21 @@ describe Doorkeeper::JWT, 'configuration' do
     end
   end
 
+  describe 'use_application_secret' do
+    it 'defaults to false' do
+      Doorkeeper::JWT.configure do
+      end
+      expect(subject.use_application_secret).to be false
+    end
+
+    it 'changes the value of secret_key to the applicatin\'s secret' do
+      Doorkeeper::JWT.configure do
+        use_application_secret true
+      end
+      expect(subject.use_application_secret).to be true
+    end
+  end
+
   describe 'secret_key' do
     it 'defaults to nil' do
       Doorkeeper::JWT.configure do

--- a/spec/doorkeeper-jwt/doorkeeper-jwt_spec.rb
+++ b/spec/doorkeeper-jwt/doorkeeper-jwt_spec.rb
@@ -140,11 +140,11 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["alg"]).to eq "RS512"
     end
 
-    it "creates a signed JWT token encrypted with an application key from a string" do
+    it "creates a signed JWT token encrypted with an app secret" do
       secret_key = OpenSSL::PKey::RSA.new(1024)
       Doorkeeper::JWT.configure do
         use_application_secret true
-        token_payload do |opts|
+        token_payload do
           {
             foo: "bar"
           }
@@ -153,7 +153,7 @@ describe Doorkeeper::JWT do
         encryption_method :rs512
       end
 
-      token = Doorkeeper::JWT.generate({application: {secret: secret_key}})
+      token = Doorkeeper::JWT.generate(application: { secret: secret_key })
       decoded_token = ::JWT.decode(token, secret_key, "RS512")
       expect(decoded_token[0]).to be_a(Hash)
       expect(decoded_token[0]["foo"]).to eq "bar"

--- a/spec/doorkeeper-jwt/doorkeeper-jwt_spec.rb
+++ b/spec/doorkeeper-jwt/doorkeeper-jwt_spec.rb
@@ -139,5 +139,26 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "RS512"
     end
+
+    it "creates a signed JWT token encrypted with an application key from a string" do
+      secret_key = OpenSSL::PKey::RSA.new(1024)
+      Doorkeeper::JWT.configure do
+        use_application_secret true
+        token_payload do |opts|
+          {
+            foo: "bar"
+          }
+        end
+        secret_key secret_key.to_s
+        encryption_method :rs512
+      end
+
+      token = Doorkeeper::JWT.generate({application: {secret: secret_key}})
+      decoded_token = ::JWT.decode(token, secret_key, "RS512")
+      expect(decoded_token[0]).to be_a(Hash)
+      expect(decoded_token[0]["foo"]).to eq "bar"
+      expect(decoded_token[1]["typ"]).to eq "JWT"
+      expect(decoded_token[1]["alg"]).to eq "RS512"
+    end
   end
 end


### PR DESCRIPTION
This should allow the configuration setting `use_application_secret` which will then use the grant token's application secret when generating the JWT. I believe this was mentioned in Issue #2