### PR TITLE
Use Application Secret

### DIFF
--- a/lib/doorkeeper-jwt.rb
+++ b/lib/doorkeeper-jwt.rb
@@ -41,7 +41,7 @@ module Doorkeeper
       end
 
       def use_application_secret?
-        return Doorkeeper::JWT.configuration.use_application_secret
+        Doorkeeper::JWT.configuration.use_application_secret
       end
 
       def application_secret(opts)

--- a/lib/doorkeeper-jwt.rb
+++ b/lib/doorkeeper-jwt.rb
@@ -41,7 +41,7 @@ module Doorkeeper
       end
 
       def use_application_secret?
-        return false unless Doorkeeper::JWT.configuration.use_application_secret
+        return Doorkeeper::JWT.configuration.use_application_secret
       end
 
       def application_secret(opts)


### PR DESCRIPTION
The [following line](https://github.com/chriswarren/doorkeeper-jwt/blob/master/lib/doorkeeper-jwt.rb#L43) appears to be invalid

``` ruby
def use_application_secret?
  return false unless Doorkeeper::JWT.configuration.use_application_secret
end
```

When this is set to `true` the response is `nil` meaning it actually fails to use the application secret. Is there any reason I'm missing for not directly returning the value from configuration since it has a default value?

``` ruby
def use_application_secret?
  Doorkeeper::JWT.configuration.use_application_secret
end
```
