### PR TITLE
Remove outdated references to Doorkeeper release SHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@
 
 # Doorkeeper::JWT
 
-Doorkeeper JWT adds JWT token support to the Doorkeeper OAuth library. Requires Doorkeeper 2.2.0 or newer. Until it is released (expected mid-April, 2015), you can load the necessary commit that addis custom token support in your gemfile.
-
-```ruby
-gem 'doorkeeper', git: "git://github.com/doorkeeper/doorkeeper-gem", ref: '910112'
-```
+Doorkeeper JWT adds JWT token support to the Doorkeeper OAuth library. Requires Doorkeeper 2.2.0 or newer. 
 
 ## Installation
 


### PR DESCRIPTION
The Doorkeeper 2.2 release did happen on time and now we're up to 4.0, so it is time to retire the suggestion to use a specific SHA while waiting on the release to be cut in mid 2015.
