### PR TITLE
fix use application secret

### DIFF
--- a/lib/doorkeeper-jwt.rb
+++ b/lib/doorkeeper-jwt.rb
@@ -41,7 +41,7 @@ module Doorkeeper
       end
 
       def use_application_secret?
-        return false unless Doorkeeper::JWT.configuration.use_application_secret
+        Doorkeeper::JWT.configuration.use_application_secret
       end
 
       def application_secret(opts)


### PR DESCRIPTION
return application_secret(opts) if use_application_secret? not getting called because it returns nil 