### PR TITLE
Ensure secret_key_path files are closed after use

### DIFF
--- a/lib/doorkeeper-jwt.rb
+++ b/lib/doorkeeper-jwt.rb
@@ -67,15 +67,15 @@ module Doorkeeper
       end
 
       def rsa_key_file
-        OpenSSL::PKey::RSA.new(secret_key_file_open)
+        secret_key_file_open { |f| OpenSSL::PKey::RSA.new(f) }
       end
 
       def ecdsa_key_file
-        OpenSSL::PKey::EC.new(secret_key_file_open)
+        secret_key_file_open { |f| OpenSSL::PKey::EC.new(f) }
       end
 
-      def secret_key_file_open
-        File.open(Doorkeeper::JWT.configuration.secret_key_path)
+      def secret_key_file_open(&block)
+        File.open(Doorkeeper::JWT.configuration.secret_key_path, &block)
       end
     end
   end


### PR DESCRIPTION
It seems that `OpenSSL` doesn't close the file handles it's passed, so here the block form of `File.open` is used instead to ensure the secret files don't remain open in the process.
