### PR TITLE
Doorkeeper installation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Doorkeeper JWT adds JWT token support to the Doorkeeper OAuth library. Requires Doorkeeper 2.2.0 or newer. Until it is released (expected mid-April, 2015), you can load the necessary commit that addis custom token support in your gemfile.
 
 ```ruby
-gem 'doorkeeper', git: "git://github.com/doorkeeper/doorkeeper-gem", ref: '910112'
+gem 'doorkeeper'
 ```
 
 ## Installation


### PR DESCRIPTION
The correct url is https://github.com/doorkeeper-gem/doorkeeper
The prefered bundler method to user github is `gem 'doorkeeper', github: 'doorkeeper-gem/doorkeeper', ref: 910112
current Doorkeeper version is > 4.0, we don't need the step above :)