### PR TITLE
Allow custom token headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Doorkeeper::JWT.configure do
     }
   end
 
+  # Optionally set additional headers for the JWT. See https://tools.ietf.org/html/rfc7515#section-4.1
+  token_headers do |opts|
+    {
+      kid: opts[:application][:uid]
+    }
+  end
+
   # Use the application secret specified in the Access Grant token
   # Defaults to false
   # If you specify `use_application_secret true`, both secret_key and secret_key_path will be ignored

--- a/lib/doorkeeper-jwt.rb
+++ b/lib/doorkeeper-jwt.rb
@@ -9,7 +9,8 @@ module Doorkeeper
         ::JWT.encode(
           token_payload(opts),
           secret_key(opts),
-          encryption_method
+          encryption_method,
+          token_headers
         )
       end
 
@@ -17,6 +18,10 @@ module Doorkeeper
 
       def token_payload(opts = {})
         Doorkeeper::JWT.configuration.token_payload.call opts
+      end
+
+      def token_headers(opts = {})
+        Doorkeeper::JWT.configuration.token_headers.call opts
       end
 
       def secret_key(opts)

--- a/lib/doorkeeper-jwt/config.rb
+++ b/lib/doorkeeper-jwt/config.rb
@@ -111,6 +111,7 @@ module Doorkeeper
 
       option :token_payload,
         default: proc{ { token: SecureRandom.method(:hex) } }
+      option :token_headers, default: proc { {} }
       option :use_application_secret, default: false
       option :secret_key, default: nil
       option :secret_key_path, default: nil

--- a/spec/doorkeeper-jwt/config_spec.rb
+++ b/spec/doorkeeper-jwt/config_spec.rb
@@ -20,6 +20,23 @@ describe Doorkeeper::JWT, 'configuration' do
     end
   end
 
+  describe "token_headers" do
+    it "is nil by default" do
+      Doorkeeper::JWT.configure do
+      end
+
+      expect(subject.token_headers).to be_a(Proc)
+    end
+
+    it "sets the block that is accessible via authenticate_admin" do
+      block = proc {}
+      Doorkeeper::JWT.configure do
+        token_headers(&block)
+      end
+      expect(subject.token_headers).to eq(block)
+    end
+  end
+
   describe 'encryption_method' do
     it 'defaults to nil' do
       Doorkeeper::JWT.configure do

--- a/spec/doorkeeper-jwt/doorkeeper-jwt_spec.rb
+++ b/spec/doorkeeper-jwt/doorkeeper-jwt_spec.rb
@@ -35,6 +35,23 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["alg"]).to eq "none"
     end
 
+    it "creates a JWT token with custom headers" do
+      Doorkeeper::JWT.configure do
+        token_headers do
+          {
+            kid: "foo"
+          }
+        end
+      end
+
+      token = Doorkeeper::JWT.generate({})
+      decoded_token = ::JWT.decode(token, nil, false)
+      expect(decoded_token[1]).to be_a(Hash)
+      expect(decoded_token[1]["typ"]).to eq "JWT"
+      expect(decoded_token[1]["alg"]).to eq "none"
+      expect(decoded_token[1]["kid"]).to eq "foo"
+    end
+
     it "creates a signed JWT token" do
       Doorkeeper::JWT.configure do
         secret_key "super secret"


### PR DESCRIPTION
Per the [JWS spec](https://tools.ietf.org/html/rfc7515#section-4.1.4), there are a number of useful headers that can be specified including `kid`. This PR allows an additional configuration block to be provided (`token_headers`) such that apps can specify additional headers in their tokens.