### PR TITLE
Pass opts to token_headers

### DIFF
--- a/lib/doorkeeper-jwt.rb
+++ b/lib/doorkeeper-jwt.rb
@@ -10,7 +10,7 @@ module Doorkeeper
           token_payload(opts),
           secret_key(opts),
           encryption_method,
-          token_headers
+          token_headers(opts)
         )
       end
 

--- a/lib/doorkeeper-jwt/version.rb
+++ b/lib/doorkeeper-jwt/version.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
   module JWT
-    VERSION = "0.2.0".freeze
+    VERSION = "0.2.1".freeze
   end
 end

--- a/spec/doorkeeper-jwt/doorkeeper-jwt_spec.rb
+++ b/spec/doorkeeper-jwt/doorkeeper-jwt_spec.rb
@@ -35,16 +35,16 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["alg"]).to eq "none"
     end
 
-    it "creates a JWT token with custom headers" do
+    it "creates a JWT token with custom dynamic headers" do
       Doorkeeper::JWT.configure do
-        token_headers do
+        token_headers do |opts|
           {
-            kid: "foo"
+            kid: opts[:application][:uid]
           }
         end
       end
 
-      token = Doorkeeper::JWT.generate({})
+      token = Doorkeeper::JWT.generate(application: { uid: "foo" })
       decoded_token = ::JWT.decode(token, nil, false)
       expect(decoded_token[1]).to be_a(Hash)
       expect(decoded_token[1]["typ"]).to eq "JWT"


### PR DESCRIPTION
This fixes the bug mentioned here: https://github.com/chriswarren/doorkeeper-jwt/commit/ac6f1c50628e4c1d9e5b4a51d6fbca3c5e1030db#commitcomment-22429204

The `token_headers` accepts `opts` like the other procs, but wasn't being called with them. This adds the arg and updates the test to reflect the fix.