### PR TITLE
docs(readme): Update default token_payload config to include exp claim when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Doorkeeper::JWT.configure do
     user = User.find(opts[:resource_owner_id])
 
     {
+      exp: (opts[:created_at] + opts[:expires_in]).utc.to_i,
       iss: 'My App',
-      iat: Time.current.utc.to_i,
+      iat: opts[:created_at].utc.to_i,
       aud: opts[:application][:uid],
 
       # @see JWT reserved claims - https://tools.ietf.org/html/draft-jones-json-web-token-07#page-7

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ Doorkeeper::JWT.configure do
   token_payload do |opts|
     user = User.find(opts[:resource_owner_id])
 
-    {
-      exp: (opts[:created_at] + opts[:expires_in]).utc.to_i,
+    payload = {
       iss: 'My App',
       iat: opts[:created_at].utc.to_i,
       aud: opts[:application][:uid],
@@ -61,6 +60,9 @@ Doorkeeper::JWT.configure do
         email: user.email
       }
     }
+
+    payload[:exp] = (opts[:created_at] + opts[:expires_in]).utc.to_i if opts[:expires_in]
+    payload
   end
 
   # Optionally set additional headers for the JWT. See


### PR DESCRIPTION
Hi, actually it is highly recommended to set the `exp` claim when `expires_in` is not nil otherwise generated JWT Token could be used indefinitly.
Also updated slightly the `iat` claim. Better to use the same value that come from Doorkeeper.